### PR TITLE
API の呼び出しをリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ bower_components
 
 # troublesome when pull, push, commit
 public/js/bundle.js
+
+# dotenv file
+.env

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "bower": "^1.6.8",
+    "dotenv": "^2.0.0",
     "html-loader": "^0.4.0",
     "webpack": "^1.12.9"
   }

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -9,8 +9,19 @@ module.exports = {
     return util.apiGet('/rooms/' + params.roomId + '/initialValue');
   },
 
-  // API の仕様のため，resultTimeのパラメータでスコアアタック時の結果のAnswerNumを送ってます
   getRanking: function (userId, roomId, resultTime, rankCount, rankSort) {
 	   return util.apiGet('/ranks?userId=' + userId + '&roomId=' + roomId + '&resultTime=' + resultTime + '&rankCount=' + rankCount + '&rankSort=' + rankSort);
+  },
+
+  sessionCreate: function (params) {
+    return util.apiPost('/session', params);
+  },
+
+  roomsCreate: function (params) {
+    return util.apiPost('/rooms', params);
+  },
+
+  ranksIndex: function (params) {
+    return util.apiGet('/ranks', params);
   }
 };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,6 +1,6 @@
 module.exports = {
   callApi: function (method, path, data) {
-    var hostname = 'ec2-52-192-125-118.ap-northeast-1.compute.amazonaws.com/';
+    var hostname = CITYTORY_API_SERVER;
     var url = 'http://' + hostname + '/citytori/api' + path;
 
     return $.ajax({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
+require('dotenv').config();
 
 module.exports = {
   entry: './src/js/main.js',
@@ -27,6 +28,9 @@ module.exports = {
       jQuery: "jquery",
       $: "jquery",
       jquery: "jquery"
+    }),
+    new webpack.DefinePlugin({
+      CITYTORY_API_SERVER: JSON.stringify(process.env.CITYTORY_API_SERVER)
     })
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
-require('dotenv').config();
+require('dotenv').config({ silent: true });
 
 module.exports = {
   entry: './src/js/main.js',
@@ -30,7 +30,8 @@ module.exports = {
       jquery: "jquery"
     }),
     new webpack.DefinePlugin({
-      CITYTORY_API_SERVER: JSON.stringify(process.env.CITYTORY_API_SERVER)
+      CITYTORY_API_SERVER:
+        JSON.stringify(process.env.CITYTORY_API_SERVER || 'http://localhost:8080')
     })
   ]
 }


### PR DESCRIPTION
# 背景
- `$.ajax` を直接呼び出しているコードが複数あり、Ajax 通信の設定等の重複が多くあった
  - 特に本番環境のサーバを直接指定していたため、開発環境のサーバの動作を確認することができなかった
# 解決策
- API 呼び出しのコードを `util.js` に移し、それぞれの API を `$.ajax` から `util.api{Get,Post}` による呼び出しに変更した
- API を呼び出すサーバの URL を `.env` ファイルに分離し、環境ごとに API サーバを別途指定できるようにした
# 注意
- `.env` ファイルが `webpack.config.js` 以下にない場合、デフォルトの API サーバは、`http://localhost:8080` になる
- 本番環境等で API サーバを変更したい場合は、`.env` ファイルを `webpack.config.js` 以下に設定を書くか、`webpack` を呼び出すときに環境変数をつけて呼び出せば良い

``` .env
# .env
CITYTORI_API_SERVER=example.com
```

or

```
$ CITYTORI_API_SERVER=example.com webpack
```
